### PR TITLE
Fix svg code not showing in rendered README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ The items are separated into layers, some items require multiple layers while ot
 All SVGs are optimized to remove as much excess styles and attributes as possible. Each layer is a group with an id that is used to show/hide the layer according to the user's choices.
 
 if you want to open an SVG to edit it, make sure you add the following in the file:
-
+```
 <svg viewBox="10 50 540 540">
 [...]
 </svg>
-
+```
 You can then edit the layer in Inkscape and export it again. Be sure to use a tool to optimize the file as much as possible (like svgomg) and replace the SVG tag by a Group tag.
 
 # License


### PR DESCRIPTION
The SVG code block in the README is not visible when rendered to HTML. It only shows as [...]